### PR TITLE
Using ':enter' in autotype patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Copy autopass from this repo somewhere in your path.
 
 - run `autopass`
 - Highlight an entry either by fuzzy search or with arrow keys
-- Press return for autotype
+- Press Enter for autotype
 - Press Alt+1 for autotype_1
 - Press Alt+2 for autotype_2
 - Press Alt+3 for autotype_3
@@ -70,10 +70,10 @@ tan: |
 ```
 
 You can write any kind of key value pairs here as long as it's valid yaml.
-Only and `autotype`, `autotype_{1-7}`, `window`, `otp_secret` and `tan` have
-special meanings. `':tab'` hits - you guessed it - the tab key, `':otp'` types
-the current time based one time password, for this you need to set `otp_secret`
-for this entry.
+The keys `autotype`, `autotype_{1-7}`, `window`, `otp_secret` and `tan` have
+special meanings. `':tab'` hits - you guessed it - the Tab key, `':enter'` hits
+the Enter key, `':otp'` types the current time based one time password.
+Make sure you add `otp_secret` to an entry when using `':otp'`.
 
 ### Config:
 

--- a/autopass
+++ b/autopass
@@ -352,15 +352,15 @@ errorneus_entry_indices = sorted_entries.each_with_index.reduce([]) do |result, 
   entry.attributes.error == true ? result << i : result
 end
 
-rofi_args = %w(-dmenu -i -z -p Search)
+rofi_args = %w(-dmenu -i -z -p Search:)
 rofi_args.concat(['-kb-custom-7', CONFIG.key_bindings.autotype_tan])
 rofi_args.concat(['-kb-custom-8', CONFIG.key_bindings.copy_password])
 rofi_args.concat(['-kb-custom-9', CONFIG.key_bindings.copy_username])
 rofi_args << '-mesg'
 rofi_args << "Alt-{1-6}: Alternative autotypes\n"\
              "#{CONFIG.key_bindings.copy_username}: Copy username\n"\
-             "#{CONFIG.key_bindings.copy_password}: Alt-p: Copy password\n"\
-             "#{CONFIG.key_bindings.autotype_tan}: Alt-t: Autotype TAN"
+             "#{CONFIG.key_bindings.copy_password}: Copy password\n"\
+             "#{CONFIG.key_bindings.autotype_tan}: Autotype TAN"
 
 unless errorneus_entry_indices.empty?
   rofi_args.concat(['-u', errorneus_entry_indices.join(',')])

--- a/autopass
+++ b/autopass
@@ -210,6 +210,7 @@ class Entry
     values.each do |value|
       case value
       when ':tab' then `xdotool key Tab`
+      when ':enter' then `xdotool key Return`
       else
         type = value == ':otp' ? otp : value
         IO.popen('xdotool type --clearmodifiers --file -', 'w+') do |io|


### PR DESCRIPTION
Hi Joakim

I added the possibility to use ':enter' in autotype patterns. This is useful for entering credentials in browsers which do not support dialog windows for authentication (like qutebrowser, dwb, etc...).
Also, I made some minor tweaks regarding ui and wording.

Best regards
Tom
